### PR TITLE
FITS.writeSimpleFITS for uint8, uint16 and uint32 image types with BZERO shift

### DIFF
--- a/matlab/image/@FITS/FITS.m
+++ b/matlab/image/@FITS/FITS.m
@@ -1023,8 +1023,11 @@ classdef FITS < handle
         
         function writeSimpleFITS(Image, FileName, Args)
             % Write a simple (single HDU) FITS file to disk
-            % using io.fits.writeSimpleFITS
-            %   This function is a few times faster compared with CFITSIO routines.
+            % using io.fits.writeSimpleFITS, which streamlines correctly
+            %   the CFITSIO routines, and is thus several times faster
+            %   than FITS.write. That routine also takes care of setting
+            %   BZERO properly for writing unsigned images with signed
+            %   types.
             % Input  : - An image data (e.g., matrix).
             %          - File name in which to write the FITS file.
             %          * ...,key,val,...

--- a/matlab/image/@FITS/FITS.m
+++ b/matlab/image/@FITS/FITS.m
@@ -1043,7 +1043,8 @@ classdef FITS < handle
                 Args.DataType                 = [];
             end
             
-            io.fits.writeSimpleFITS(Image, FileName, 'Header',Args.Header, 'DataType',Args.DataType);
+            io.fits.writeSimpleFITS(Image, FileName, 'Header',Args.Header,...
+                                     'DataType',Args.DataType,'UseMatlabIo',true);
             
         end
         

--- a/matlab/util/+io/+fits/dataType2bitpix.m
+++ b/matlab/util/+io/+fits/dataType2bitpix.m
@@ -24,8 +24,8 @@ function [BitPix,bzero] = dataType2bitpix(Class)
             error('Unknown Class option');
     end
     switch lower(Class)
-        case 'uint8'
-            bzero=128;
+        case 'int8'
+            bzero=-128;
         case 'uint16'
             bzero=2^15;
         case 'uint32'

--- a/matlab/util/+io/+fits/dataType2bitpix.m
+++ b/matlab/util/+io/+fits/dataType2bitpix.m
@@ -1,8 +1,10 @@
-function BitPix = dataType2bitpix(Class)
+function [BitPix,bzero] = dataType2bitpix(Class)
     % Convert class name to BITPIX keyword value number.
     % Input  : - A class (e.g., 'single').
     % Output : - A BITPIX value.
-    % Author : Eran Ofek (Jan 2022)
+    %          - the recommended BZERO value for the header, for unsigned
+    %            formats
+    % Author : Eran Ofek (Jan 2022) (bzero added by Enrico Segre Feb 2023)
     % Eaxmple: BitPix = io.fits.dataType2bitpix('int16')
     
     switch lower(Class)
@@ -20,6 +22,16 @@ function BitPix = dataType2bitpix(Class)
             BitPix = -64;
         otherwise
             error('Unknown Class option');
+    end
+    switch lower(Class)
+        case 'uint8'
+            bzero=128;
+        case 'uint16'
+            bzero=2^15;
+        case 'uint32'
+            bzero=2^31;
+        otherwise
+            bzero=0;
     end
 end
             

--- a/matlab/util/+io/+fits/unittestWriteSimple.m
+++ b/matlab/util/+io/+fits/unittestWriteSimple.m
@@ -1,0 +1,41 @@
+function result=unittestWriteSimple()
+% Unit test for FITS.writeSimpleFITS(), using in fact io.fits.writeSimpleFITS()
+%
+% this test might need to be written in the canonical form for unit tests,
+%  which I don't know
+% Author: Enrico Segre, Feb 2023
+
+    % test image with vertical gradient and central white square
+    im=kron(uint16(0:64:65535)',ones(1,1000,'uint16'));
+    im(size(im,1)/2+(-20:20),size(im,2)/2+(-20:20))=uint16(65535);
+    imagesc(im); colorbar
+    
+    imfile='/tmp/gradsquare.fits';
+    
+    % dummy header with a lot of entries
+    nhead=150;
+    header=cell(nhead,3);
+    for k=1:nhead
+        header(k,:)={sprintf('K%05d',k) ,rand(), 'random number'};
+    end
+
+    % write simple FITS with automatic casting and BZERO
+    %  (Astropack branch fits-u16)
+    FITS.writeSimpleFITS(im, imfile, 'Header',header);
+
+    % reread with FITS.read1()
+    imReadFITS=FITS.read1(imfile);
+
+    % this should be 0 if all was ok
+    result1=(numel(find(imReadFITS-im))==0);
+
+    % reread with matlab.io.fits
+    fptr = matlab.io.fits.openFile(imfile);
+    imreadio = matlab.io.fits.readImg(fptr);
+    matlab.io.fits.closeFile(fptr);
+
+    % also this should be 0 if all was ok
+    result2=(numel(find(imreadio-im))==0);
+
+    % final result
+    result=result1 & result2;

--- a/matlab/util/+io/+fits/unittestWriteSimple.m
+++ b/matlab/util/+io/+fits/unittestWriteSimple.m
@@ -6,9 +6,10 @@ function result=unittestWriteSimple()
 % Author: Enrico Segre, Feb 2023
 
     % test image with vertical gradient and central white square
-    im=kron(uint16(0:64:65535)',ones(1,1000,'uint16'));
-    im(size(im,1)/2+(-20:20),size(im,2)/2+(-20:20))=uint16(65535);
-    imagesc(im); colorbar
+    % (double, 0-:-1)
+    im0=kron((0:1023)'/1023,ones(1,1000));
+    im0(size(im0,1)/2+(-20:20),size(im0,2)/2+(-20:20))=1;
+    imagesc(im0); colorbar
     
     imfile='/tmp/gradsquare.fits';
     
@@ -19,23 +20,59 @@ function result=unittestWriteSimple()
         header(k,:)={sprintf('K%05d',k) ,rand(), 'random number'};
     end
 
-    % write simple FITS with automatic casting and BZERO
-    %  (Astropack branch fits-u16)
-    FITS.writeSimpleFITS(im, imfile, 'Header',header);
-
-    % reread with FITS.read1()
-    imReadFITS=FITS.read1(imfile);
-
-    % this should be 0 if all was ok
-    result1=(numel(find(imReadFITS-im))==0);
-
-    % reread with matlab.io.fits
-    fptr = matlab.io.fits.openFile(imfile);
-    imreadio = matlab.io.fits.readImg(fptr);
-    matlab.io.fits.closeFile(fptr);
-
-    % also this should be 0 if all was ok
-    result2=(numel(find(imreadio-im))==0);
+    imtype={'int8','uint8','int16','uint16','int32','uint32','single','double'};
+    result1=false(1,numel(imtype));
+    result2=result1;
+    for i=1:numel(imtype)
+        % cast im0 to the desired type and scale it
+        switch imtype{i}
+            case 'int8'
+                bmax=255; bzero=128;
+            case 'uint8'
+                bmax=255; bzero=0;
+            case 'int16'
+                bmax=65535; bzero=32678;
+            case 'uint16'
+                bmax=65535; bzero=0;
+            case 'int32'
+                bmax=2^32-1; bzero=2^31;
+            case 'uint32'
+                bmax=2^32-1; bzero=0;
+            case 'single'
+                bmax=1; bzero=0;
+            case 'double'
+                bmax=1; bzero=0;
+        end
+        im=cast(im0*bmax-bzero,imtype{i});
+       
+        try
+            fprintf('testing image type %s:\n',imtype{i})
+            % write simple FITS with automatic casting and BZERO
+            %  (Astropack branch fits-u16)
+            FITS.writeSimpleFITS(im, imfile, 'Header',header);
+            
+            % reread with FITS.read1()
+            imReadFITS=FITS.read1(imfile);
+            
+            % this should be 0 if all was ok
+            result1(i)=(numel(find(imReadFITS-im))==0);
+            
+            % reread with matlab.io.fits
+            fptr = matlab.io.fits.openFile(imfile);
+            imreadio = matlab.io.fits.readImg(fptr);
+            matlab.io.fits.closeFile(fptr);
+            
+            % also this should be 0 if all was ok
+            result2(i)=(numel(find(imreadio-im))==0);
+            if result1(i) && result2(i)
+                fprintf('test successful\n')
+            else
+                fprintf('test failed\n')
+            end
+        catch
+            fprintf('---image type %s cannot be written\n',imtype{i})
+        end
+    end
 
     % final result
-    result=result1 & result2;
+    result=all(result1 & result2);

--- a/matlab/util/+io/+fits/writeSimpleFITS.m
+++ b/matlab/util/+io/+fits/writeSimpleFITS.m
@@ -93,12 +93,12 @@ function writeSimpleFITS(Image, FileName, Args)
         % create Image
         matlab.io.fits.createImg(Fptr, NewDataType, size(Image));
 
-        % write Header        
-        FITS.writeHeader(Fptr, Header, HEAD.HeaderField);
-        
         % write Image %% datatype conversion overflow???
         matlab.io.fits.writeImg(Fptr, Image); %,Fpixels);
         
+        % write Header
+        FITS.writeHeader(Fptr, Header, HEAD.HeaderField);
+
         % Close FITS file
         matlab.io.fits.closeFile(Fptr);
     end

--- a/matlab/util/+io/+fits/writeSimpleFITS.m
+++ b/matlab/util/+io/+fits/writeSimpleFITS.m
@@ -38,22 +38,36 @@ function writeSimpleFITS(Image, FileName, Args)
     % if the class is unsigned, we must write Image-bzero as signed, and
     % change the required class.
     % To do the substraction, we have to upcast
+%     switch Args.DataType
+%         case 'uint8'
+%             Image=int8(int16(Image)-int16(bzero));
+%             Args.DataType='int8';
+%         case 'uint16'
+%             Image=int16(int32(Image)-int32(bzero));
+%             Args.DataType='int16';
+%         case 'uint32'
+%             Image=int32(int64(Image)-int64(bzero));
+%             Args.DataType='int32';
+%     end
+%     NewDataType=Args.DataType;
+
     switch Args.DataType
         case 'uint8'
-            Image=int8(int16(Image)-int16(bzero));
-            Args.DataType='int8';
+            NewDataType='int8';
         case 'uint16'
-            Image=int16(int32(Image)-int32(bzero));
-            Args.DataType='int16';
+            NewDataType='int16';
         case 'uint32'
-            Image=int32(int64(Image)-int64(bzero));
-            Args.DataType='int32';
+            NewDataType='int32';
+        otherwise
+            NewDataType=Args.DataType;
     end
-
+    Image=reshape(typecast(bitxor(Image(:),cast(bzero,Args.DataType)),...
+                           NewDataType),size(Image));
+    
     FID = fopen(FileName,'w');
     %fwrite(FID, HeaderStr, 'char', 0, 'b');
     fprintf(FID,'%s',HeaderStr);
-    io.fits.writeImageData(FID, Image, Args.DataType);
+    io.fits.writeImageData(FID, Image, NewDataType);
     fclose(FID);
 
 end

--- a/matlab/util/+io/+fits/writeSimpleFITS.m
+++ b/matlab/util/+io/+fits/writeSimpleFITS.m
@@ -93,7 +93,22 @@ function writeSimpleFITS(Image, FileName, Args)
         % create Image
         matlab.io.fits.createImg(Fptr, NewDataType, size(Image));
 
-        % write Image %% datatype conversion overflow???
+        % test filling the header with random data, BEFORE writeImg
+        % -> indeed this takes significant time if placed AFTER,
+        %    most likely because the whole file has to be rewritten if the
+        %    initial block is grown
+        % none of these causes problems:
+%         for k=1:150
+%             matlab.io.fits.writeKey(Fptr,sprintf('K%05d',k),rand(),'random number')
+%         end
+%         matlab.io.fits.writeComment(Fptr,'tarapia tapioca')
+%         matlab.io.fits.writeHistory(Fptr,'come fosse cofandina anzi vicesindaco')
+
+        % write Header (this here causes datatype conversion overflow in writeImg)
+        %FITS.writeHeader(Fptr, Header, HEAD.HeaderField);
+
+
+        % write Image %% datatype conversion overflow if FITS.writeHeader before???
         matlab.io.fits.writeImg(Fptr, Image); %,Fpixels);
         
         % write Header

--- a/matlab/util/+io/+fits/writeSimpleFITS.m
+++ b/matlab/util/+io/+fits/writeSimpleFITS.m
@@ -47,7 +47,7 @@ function writeSimpleFITS(Image, FileName, Args)
             Args.DataType='int16';
         case 'uint32'
             Image=int32(int64(Image)-int64(bzero));
-            Args.DataType='int16';
+            Args.DataType='int32';
     end
 
     FID = fopen(FileName,'w');

--- a/matlab/util/+io/+fits/writeSimpleFITS.m
+++ b/matlab/util/+io/+fits/writeSimpleFITS.m
@@ -47,8 +47,8 @@ function writeSimpleFITS(Image, FileName, Args)
 %     NewDataType=Args.DataType;
 
     switch Args.DataType
-        case 'uint8'
-            NewDataType='int8';
+        case 'int8'
+            NewDataType='uint8';
         case 'uint16'
             NewDataType='int16';
         case 'uint32'

--- a/matlab/util/+io/+fits/writeSimpleFITS.m
+++ b/matlab/util/+io/+fits/writeSimpleFITS.m
@@ -32,20 +32,6 @@ function writeSimpleFITS(Image, FileName, Args)
 
     % if the class is unsigned, we must write Image-bzero as signed, and
     % change the required class.
-    % To do the substraction, we have to upcast
-%     switch Args.DataType
-%         case 'uint8'
-%             Image=int8(int16(Image)-int16(bzero));
-%             Args.DataType='int8';
-%         case 'uint16'
-%             Image=int16(int32(Image)-int32(bzero));
-%             Args.DataType='int16';
-%         case 'uint32'
-%             Image=int32(int64(Image)-int64(bzero));
-%             Args.DataType='int32';
-%     end
-%     NewDataType=Args.DataType;
-
     switch Args.DataType
         case 'int8'
             NewDataType='uint8';
@@ -92,17 +78,6 @@ function writeSimpleFITS(Image, FileName, Args)
         % create Image
         matlab.io.fits.createImg(Fptr, NewDataType, size(Image));
 
-        % test filling the header with random data, BEFORE writeImg
-        % -> indeed this takes significant time if placed AFTER,
-        %    most likely because the whole file has to be rewritten if the
-        %    initial block is grown
-        % none of these causes problems:
-%         for k=1:150
-%             matlab.io.fits.writeKey(Fptr,sprintf('K%05d',k),rand(),'random number')
-%         end
-%         matlab.io.fits.writeComment(Fptr,'tarapia tapioca')
-%         matlab.io.fits.writeHistory(Fptr,'come fosse cofandina anzi vicesindaco')
-
         Header = FITS.prepareHeader(Args.Header, HEAD.HeaderField, 'WriteTime', true);
         FITS.writeHeader(Fptr, Header, HEAD.HeaderField);
 
@@ -112,9 +87,6 @@ function writeSimpleFITS(Image, FileName, Args)
         
         % change BZERO post-facto
         matlab.io.fits.writeKey(Fptr,'BZERO',bzero);
-
-        % write Header
-        % FITS.writeHeader(Fptr, Header, HEAD.HeaderField);
 
         % Close FITS file
         matlab.io.fits.closeFile(Fptr);


### PR DESCRIPTION
as discussed, and noted in Issue #66