### PR TITLE
Fix Handedness-dependent sign bug in cdmatrix2rotScale PA_X_deg

### DIFF
--- a/matlab/image/+imUtil/+astrometry/cdmatrix2rotScale.m
+++ b/matlab/image/+imUtil/+astrometry/cdmatrix2rotScale.m
@@ -24,13 +24,23 @@ function [Result] = cdmatrix2rotScale(CD1_1, CD1_2, CD2_1, CD2_2)
     end
         
 
+    Result.Handedness = sign(CD1_1.*CD2_2 - CD1_2.*CD2_1);
+
     Result.PA_Y_deg = atan2d(CD1_2, CD2_2);       % PA of +Y, East of North
-    Result.PA_X_deg = atan2d(CD1_1, CD2_1) - 90;       % PA of +X, East of North - > PA of +Y East of North
-    Result.PA_deg   = 0.5.*(Result.PA_X_deg + Result.PA_Y_deg);
+    % PA of +X, East of North -> PA of +Y East of North. The +/-90 deg
+    % correction rotates the +X axis estimate onto the +Y axis, and its
+    % sign must follow the Handedness: for Handedness=-1 (the common,
+    % unmirrored astronomical convention) using a fixed -90 here made
+    % PA_X_deg come out 180 deg away from PA_Y_deg for every CD matrix.
+    Result.PA_X_deg = mod(atan2d(CD1_1, CD2_1) - 90.*Result.Handedness + 180, 360) - 180;
+    % Circular mean: PA_X_deg and PA_Y_deg are angles wrapped to (-180,180],
+    % so a plain arithmetic mean would be wrong by 180 deg whenever they
+    % fall on opposite sides of the wrap.
+    Result.PA_deg   = atan2d(sind(Result.PA_X_deg) + sind(Result.PA_Y_deg), ...
+                              cosd(Result.PA_X_deg) + cosd(Result.PA_Y_deg));
     Result.ScaleX   = hypot(CD1_1, CD2_1);
     Result.ScaleY   = hypot(CD1_2, CD2_2);
     Result.Scale    = 0.5.*(Result.ScaleX + Result.ScaleY);
-    Result.Handedness = sign(CD1_1.*CD2_2 - CD1_2.*CD2_1);         
 
 
 end

--- a/matlab/image/+imUtil/+astrometry/unitTest.m
+++ b/matlab/image/+imUtil/+astrometry/unitTest.m
@@ -1,0 +1,38 @@
+function Result = unitTest()
+    % unitTest for the imUtil.astrometry package
+    % Example: imUtil.astrometry.unitTest
+
+    %% imUtil.astrometry.cdmatrix2rotScale
+    % For a pure-rotation (no distortion) CD matrix, PA_X_deg and PA_Y_deg
+    % must agree (regardless of Handedness), and PA_deg must track the
+    % applied rotation correctly all the way around the circle - including
+    % relative rotations that straddle the +/-180 deg wrap.
+    Scale = 1./3600;
+    for HBase = [-1, 1]   % exercise both Handedness conventions
+        CD1 = Scale.*[HBase, 0; 0, 1];
+        St1 = imUtil.astrometry.cdmatrix2rotScale(CD1(1,1), CD1(1,2), CD1(2,1), CD1(2,2));
+        if abs(mod(St1.PA_X_deg - St1.PA_Y_deg + 180, 360) - 180) > 1e-9
+            error('imUtil.astrometry.cdmatrix2rotScale: PA_X_deg and PA_Y_deg disagree for a pure-rotation CD matrix (Handedness=%d)', HBase);
+        end
+
+        for Beta = -180:15:180
+            Rm  = [cosd(Beta), sind(Beta); -sind(Beta), cosd(Beta)];
+            CD2 = CD1*Rm;
+            St2 = imUtil.astrometry.cdmatrix2rotScale(CD2(1,1), CD2(1,2), CD2(2,1), CD2(2,2));
+
+            if abs(mod(St2.PA_X_deg - St2.PA_Y_deg + 180, 360) - 180) > 1e-9
+                error('imUtil.astrometry.cdmatrix2rotScale: PA_X_deg and PA_Y_deg disagree at Beta=%g (Handedness=%d)', Beta, HBase);
+            end
+
+            % Right-multiplying CD1 by Rm(Beta) shifts PA_Y_deg by +Beta for
+            % Handedness=+1, and by -Beta for Handedness=-1.
+            Expected = mod(HBase.*Beta + 180, 360) - 180;
+            Coded    = mod(St2.PA_deg - St1.PA_deg + 180, 360) - 180;
+            if abs(mod(Expected - Coded + 180, 360) - 180) > 1e-9
+                error('imUtil.astrometry.cdmatrix2rotScale: PA_deg difference wrong at Beta=%g (Handedness=%d, expected %g, got %g)', Beta, HBase, Expected, Coded);
+            end
+        end
+    end
+
+    Result = true;
+end


### PR DESCRIPTION
## Summary
- `imUtil.astrometry.cdmatrix2rotScale`'s `PA_X_deg` used a fixed `-90` deg correction to rotate the raw +X-axis PA estimate onto the +Y axis, which implicitly assumed `Handedness=+1`. For `Handedness=-1` (the standard, unmirrored astronomical CD-matrix convention), this made `PA_X_deg` come out **exactly 180 deg away from `PA_Y_deg`, for every rotation angle** — not just a narrow edge case.
- `PA_deg = 0.5*(PA_X_deg+PA_Y_deg)` therefore averaged two effectively-antipodal angles for any `Handedness=-1` CD matrix; whether the result landed near the true value or ~180 deg off depended on which side of `atan2d`'s branch cut each raw estimate fell on.
- This corrupts `imProc.transIm.register`'s PSF-rotation angle (#892) and `pipeline.last.quality.db.cameraRotationStatus`'s reported per-camera rotation for real (Handedness=-1) LAST images.
- Fix: make the `-90`/`+90` correction `Handedness`-dependent, wrap `PA_X_deg` back into `(-180,180]`, and average via a circular mean instead of a plain arithmetic mean.

Fixes #1127. See also #892 (`imProc.transIm.register`'s PSF-rotation direction, and the related `imrotate_sinc` sign fix already merged).

## Test plan
- [x] New `imUtil.astrometry.unitTest`: sweeps `Handedness` in `{-1,1}` and relative rotation `Beta` over `-180:15:180` deg for a pure-rotation CD matrix; asserts `PA_X_deg == PA_Y_deg` (mod 360) and that `PA_deg` differences reproduce the applied rotation, in both cases.
- [x] Verified manually that before the fix, `PA_X_deg` was exactly 180 deg off `PA_Y_deg` for `Handedness=-1` at every tested angle, and that the plain-average `PA_deg` was wrong for `Beta` roughly in `(90,180)` deg — matching the original #1127 report.
- [x] Ran `imUtil.trans.unitTest` and `imProc.transIm.unitTest` — unaffected, still pass.